### PR TITLE
synchro: pull in and re-export more Libra crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
           RUSTFLAGS: -D warnings
         with:
           command: test
-          args: --release
+          args: --all --release
 
   fmt:
     name: Rustfmt
@@ -94,7 +94,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all -- -D warnings
 
   # TODO: use actions-rs/audit-check
   security_audit:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,9 +3000,14 @@ dependencies = [
 
 [[package]]
 name = "synchro"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "consensus 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "executor 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "libra-config 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "libra-crypto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "libra-types 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3014,6 +3019,7 @@ dependencies = [
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synchro 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ failure = "0.1"
 gumdrop = "0.7"
 lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
+synchro = { version = "0.1", path = "synchro" }
 
 [dev-dependencies.abscissa_core]
 version = "0.4.0"
 features = ["testing"]
-

--- a/synchro/Cargo.toml
+++ b/synchro/Cargo.toml
@@ -5,7 +5,7 @@ Byzantine Fault Tolerant consensus library built on HotStuff BFT
 used by the Synchronicity reproducible build system
 """
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
-version    = "0.0.0"
+version    = "0.1.0"
 homepage   = "https://github.com/iqlusioninc/synchronicity"
 repository = "https://github.com/iqlusioninc/synchronicity/tree/develop/synchro"
 edition    = "2018"
@@ -19,3 +19,16 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 consensus = { git = "https://github.com/iqlusioninc/libra.git", branch = "synchro" }
+executor = { git = "https://github.com/iqlusioninc/libra.git", branch = "synchro" }
+libra-config = { git = "https://github.com/iqlusioninc/libra.git", branch = "synchro" }
+parity-multiaddr = { version = "0.5", default-features = false }
+
+[dependencies.crypto]
+package = "libra-crypto"
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.types]
+package = "libra-types"
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"

--- a/synchro/src/config.rs
+++ b/synchro/src/config.rs
@@ -1,0 +1,3 @@
+//! Configuration types (from `libra-config`)
+
+pub use libra_config::{config::*, keys, seed_peers, trusted_peers, utils};

--- a/synchro/src/lib.rs
+++ b/synchro/src/lib.rs
@@ -1,3 +1,7 @@
 //! Synchro
 
-pub use consensus::chained_bft::chained_bft_consensus_provider::ChainedBftProvider;
+pub mod config;
+
+pub use consensus;
+pub use executor;
+pub use types;


### PR DESCRIPTION
- `executor`
- `libra-config`
- `libra-crypto`
- `libra-types`