### PR TITLE
synchronicity: `init` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,19 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "hkd32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle-encoding 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hmac"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +2992,14 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "subtle-encoding"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,10 +3025,12 @@ version = "0.1.0"
 dependencies = [
  "consensus 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "executor 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "hkd32 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-crypto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-types 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3020,6 +3043,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "synchro 0.1.0",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3887,6 +3911,20 @@ dependencies = [
 name = "zeroize"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "zstd-sys"
@@ -4024,6 +4062,7 @@ dependencies = [
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+"checksum hkd32 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ec8449a5d1c7ea34a75bc45e91097d2768dfb056f37fa55a465f3c3ba7c0721"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2790658cddc82e82b08e25176c431d7015a0adeb1718498715cbd20138a0bf68"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
@@ -4209,6 +4248,7 @@ dependencies = [
 "checksum structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
+"checksum subtle-encoding 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc5188a16f729680b6d495b0deaa776944b8e509d24b7f989489b0d8bbcb63b"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
@@ -4296,4 +4336,5 @@ dependencies = [
 "checksum x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
 "checksum yamux 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2758f29014c1cb7a6e74c1b1160ac8c8203be342d35b73462fc6a13cc6385423"
 "checksum zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdc979d9b5ead18184c357c4d8a3f81b579aae264e32507223032e64715462d3"
+"checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 "checksum zstd-sys 1.4.15+zstd.1.4.4 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "synchronicity"
 description = """
 Distributed build system providing cryptographic proofs-of-reproducibility
-via Byzantine Fault Tolerant (BFT) consensus.
+via BFT consensus.
 """
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 version    = "0.0.1"
@@ -26,6 +26,9 @@ gumdrop = "0.7"
 lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 synchro = { version = "0.1", path = "synchro" }
+
+[dev-dependencies]
+tempfile = "3"
 
 [dev-dependencies.abscissa_core]
 version = "0.4.0"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,9 +1,10 @@
 //! Synchronicity Subcommands
 
+mod init;
 mod start;
 mod version;
 
-use self::{start::StartCmd, version::VersionCmd};
+use self::{init::InitCmd, start::StartCmd, version::VersionCmd};
 use crate::config::SynchronicityConfig;
 use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use std::path::PathBuf;
@@ -18,13 +19,17 @@ pub enum SynchronicityCmd {
     #[options(help = "get usage information")]
     Help(Help<Self>),
 
-    /// The `start` subcommand
-    #[options(help = "start the application")]
-    Start(StartCmd),
-
     /// The `version` subcommand
     #[options(help = "display version information")]
     Version(VersionCmd),
+
+    /// The `init` subcommand
+    #[options(help = "initialize application home/config")]
+    Init(InitCmd),
+
+    /// The `start` subcommand
+    #[options(help = "start the application")]
+    Start(StartCmd),
 }
 
 impl Configurable<SynchronicityConfig> for SynchronicityCmd {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,88 @@
+//! `init` subcommand
+
+use crate::prelude::*;
+use abscissa_core::{Command, Options, Runnable};
+use std::{fs, path::PathBuf, process::exit};
+use synchro::config::{self, peer_info, KeySeed};
+
+/// Derivation component used when computing seed
+pub const DERIVATION_COMPONENT: &[u8] = b"synchronicity";
+
+/// `init` subcommand
+#[derive(Command, Debug, Options)]
+pub struct InitCmd {
+    /// Listen address to bind to (default 0.0.0.0)
+    #[options(short = "l", long = "listen", help = "listen on this IP address")]
+    listen_address: Option<String>,
+
+    /// Path to the base directory
+    #[options(free)]
+    base_dir: Vec<PathBuf>,
+}
+
+impl Runnable for InitCmd {
+    /// Initialize application configuration.
+    fn run(&self) {
+        if self.base_dir.len() != 1 {
+            status_err!("usage: synchronicity init /path/to/syncronicity/base/dir");
+            exit(1);
+        }
+
+        // TODO(tarcieri): support for reusing a previously generated `KeySeed`
+        let key_seed = KeySeed::generate();
+
+        let base_dir = self.base_dir[0].as_path();
+        fs::create_dir_all(base_dir).unwrap_or_else(|e| {
+            status_err!("couldn't create base dir: {}", e);
+            exit(1);
+        });
+
+        let mut builder = config::Builder::new(key_seed);
+        builder.with_output_dir(base_dir);
+
+        if let Some(listen_addr) = &self.listen_address {
+            builder.with_listen_address(listen_addr);
+        }
+
+        // Generate private keys as well as consensus and network configs
+        let (private_keys, consensus_peers_config, network_peers_config) =
+            builder.generate_keys_and_configs(DERIVATION_COMPONENT, 0);
+
+        let peer_id = network_peers_config.peers.keys().next().unwrap().to_owned();
+
+        builder.generate_peer_info(&peer_id, consensus_peers_config, network_peers_config);
+        status_ok!(
+            "Generated",
+            "{}",
+            base_dir.join(peer_info::DEFAULT_FILENAME).display()
+        );
+
+        let (_account, (consensus_private_key, network_private_keys)) =
+            private_keys.into_iter().next().unwrap();
+
+        let consensus_config = builder.generate_consensus_config(consensus_private_key);
+        status_ok!(
+            "Generated",
+            "{}",
+            base_dir
+                .join(&consensus_config.consensus_keypair_file)
+                .display()
+        );
+
+        let network_config = builder.generate_network_config(&peer_id, network_private_keys);
+        status_ok!(
+            "Generated",
+            "{}",
+            base_dir
+                .join(&network_config.network_keypairs_file)
+                .display()
+        );
+
+        builder.generate_node_config(consensus_config, network_config);
+        status_ok!(
+            "Generated",
+            "{}",
+            base_dir.join("node.config.toml").display()
+        );
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,3 +12,6 @@ pub use abscissa_core::{ensure, fail, fatal};
 
 /// Logging macros
 pub use abscissa_core::log::{debug, error, info, log, log_enabled, trace, warn};
+
+/// Status macros
+pub use abscissa_core::{status_err, status_info, status_ok, status_warn};

--- a/synchro/Cargo.toml
+++ b/synchro/Cargo.toml
@@ -18,13 +18,28 @@ keywords   = ["bft", "consensus", "hotstuff", "libra"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-consensus = { git = "https://github.com/iqlusioninc/libra.git", branch = "synchro" }
-executor = { git = "https://github.com/iqlusioninc/libra.git", branch = "synchro" }
-libra-config = { git = "https://github.com/iqlusioninc/libra.git", branch = "synchro" }
+hkd32 = { version = "0.3", features = ["mnemonic"] }
 parity-multiaddr = { version = "0.5", default-features = false }
+serde = { version = "1", features = ["serde_derive"] }
+
+#
+# Libra Core Dependencies
+#
+
+[dependencies.consensus]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
 
 [dependencies.crypto]
 package = "libra-crypto"
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.executor]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.libra-config]
 git = "https://github.com/iqlusioninc/libra.git"
 branch = "synchro"
 

--- a/synchro/src/config.rs
+++ b/synchro/src/config.rs
@@ -1,3 +1,8 @@
 //! Configuration types (from `libra-config`)
 
+pub mod builder;
+pub mod key_seed;
+pub mod peer_info;
+
+pub use self::{builder::Builder, key_seed::KeySeed, peer_info::PeerInfo};
 pub use libra_config::{config::*, keys, seed_peers, trusted_peers, utils};

--- a/synchro/src/config/builder.rs
+++ b/synchro/src/config/builder.rs
@@ -1,0 +1,217 @@
+//! Libra configuration builder.
+//!
+//! Parts adapted from upstream Libra's `SwarmConfigBuilder`:
+//! <https://github.com/libra/libra/blob/master/config/config-builder/src/swarm_config.rs>
+
+use super::{
+    key_seed::KeySeed,
+    keys::{ConsensusKeyPair, NetworkKeyPairs},
+    peer_info::{self, PeerInfo},
+    trusted_peers::{
+        self, ConsensusPeersConfig, ConsensusPrivateKey, NetworkPeersConfig, NetworkPrivateKeys,
+    },
+    ConsensusConfig, NetworkConfig, NodeConfig, PersistableConfig, RoleType,
+};
+use crate::types::account_address::AccountAddress;
+use parity_multiaddr::Multiaddr;
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    path::{Path, PathBuf},
+};
+
+/// Default address to listen on
+pub const DEFAULT_LISTEN_ADDRESS: &str = "0.0.0.0";
+
+/// Default port to listen on
+pub const DEFAULT_PORT: u16 = 6180;
+
+/// Libra configuration builder
+pub struct Builder {
+    /// Seed to use when generating keys (default random)
+    key_seed: KeySeed,
+
+    /// Output directory
+    output_dir: PathBuf,
+
+    /// Address to listen on
+    listen_address: Multiaddr,
+
+    /// Address to advertise to the network
+    advertised_address: Multiaddr,
+
+    /// Node `RoleType` (either `Validator` or `FullNode`)
+    role: RoleType,
+
+    /// Is this network permissioned?
+    is_permissioned: bool,
+
+    /// Seed address to include in `peer_info.toml`
+    seed_address: Option<Multiaddr>,
+}
+
+impl Builder {
+    /// Create a new config builder
+    pub fn new(key_seed: KeySeed) -> Self {
+        let listen_address =
+            parse_multiaddr_from_ipv4(DEFAULT_LISTEN_ADDRESS, DEFAULT_PORT).unwrap();
+
+        let advertised_address = listen_address.clone();
+
+        Self {
+            output_dir: PathBuf::from("."),
+            listen_address,
+            advertised_address,
+            key_seed,
+            role: RoleType::Validator,
+            is_permissioned: true,
+            seed_address: None,
+        }
+    }
+
+    /// Set output directory
+    pub fn with_output_dir(&mut self, output_dir: impl AsRef<Path>) -> &mut Self {
+        self.output_dir = output_dir.as_ref().to_path_buf();
+        self
+    }
+
+    /// Set listen address
+    pub fn with_listen_address(&mut self, listen_address: impl Display) -> &mut Self {
+        self.listen_address = parse_multiaddr_from_ipv4(listen_address, DEFAULT_PORT).unwrap();
+        self
+    }
+
+    /// Set advertised address
+    pub fn with_advertised_address(&mut self, advertised_address: impl Display) -> &mut Self {
+        self.advertised_address =
+            parse_multiaddr_from_ipv4(advertised_address, DEFAULT_PORT).unwrap();
+        self
+    }
+
+    /// Configure whether or not the network is permissioned
+    pub fn with_is_permissioned(&mut self, is_permissioned: bool) -> &mut Self {
+        // TODO(tarcieri): support permissionless networks
+        assert!(
+            !is_permissioned,
+            "support for `is_permissioned: false` unimplemented"
+        );
+        self
+    }
+
+    /// Configure a seed IP address for this node to include in `peer_info.toml`
+    pub fn with_seed_address(&mut self, seed_address: impl Display) -> &mut Self {
+        self.seed_address = Some(parse_multiaddr_from_ipv4(seed_address, DEFAULT_PORT).unwrap());
+        self
+    }
+
+    /// Generate keys and initial configuration settings
+    pub fn generate_keys_and_configs(
+        &self,
+        domain: &[u8],
+        version: u32,
+    ) -> (
+        HashMap<AccountAddress, (ConsensusPrivateKey, NetworkPrivateKeys)>,
+        ConsensusPeersConfig,
+        NetworkPeersConfig,
+    ) {
+        let seed = self.key_seed.derive_seed(domain, version);
+        trusted_peers::ConfigHelpers::gen_validator_nodes(1, Some(seed))
+    }
+
+    /// Generate `ConsensusConfig` and write `consensus_keypair.config.toml`
+    pub fn generate_consensus_config(&self, private_key: ConsensusPrivateKey) -> ConsensusConfig {
+        let consensus_config = ConsensusConfig::default();
+
+        let consensus_keypair = ConsensusKeyPair::load(Some(private_key.consensus_private_key));
+        let consensus_keypair_file = self
+            .output_dir
+            .join(&consensus_config.consensus_keypair_file);
+
+        consensus_keypair.save_config(&consensus_keypair_file);
+        consensus_config
+    }
+
+    /// Generate `NetworkConfig` and write `network_keypairs.config.toml`
+    pub fn generate_network_config(
+        &self,
+        peer_id: &str,
+        private_keys: NetworkPrivateKeys,
+    ) -> NetworkConfig {
+        let network_keypairs = NetworkKeyPairs::load(
+            private_keys.network_signing_private_key,
+            private_keys.network_identity_private_key,
+        );
+
+        let mut network_config = NetworkConfig::default();
+        network_config.peer_id = peer_id.to_owned();
+
+        network_config.role = match self.role {
+            RoleType::Validator => "validator",
+            RoleType::FullNode => "full_node",
+        }
+        .to_owned();
+
+        network_config.listen_address = self.listen_address.clone();
+        network_config.advertised_address = self.advertised_address.clone();
+        network_config.is_permissioned = self.is_permissioned;
+
+        let network_keypairs_file = self.output_dir.join(&network_config.network_keypairs_file);
+        network_keypairs.save_config(&network_keypairs_file);
+        network_config
+    }
+
+    /// Generate `NodeConfig` and write `node.config.toml`
+    pub fn generate_node_config(
+        &self,
+        consensus_config: ConsensusConfig,
+        network_config: NetworkConfig,
+    ) -> NodeConfig {
+        let node_config = NodeConfig {
+            base: Default::default(),
+            networks: vec![network_config],
+            consensus: consensus_config,
+            metrics: Default::default(),
+            execution: Default::default(),
+            admission_control: Default::default(),
+            debug_interface: Default::default(),
+            storage: Default::default(),
+            mempool: Default::default(),
+            state_sync: Default::default(),
+            log_collector: Default::default(),
+            vm_config: Default::default(),
+        };
+
+        let node_config_file = self.output_dir.join("node.config.toml");
+        node_config.save_config(&node_config_file);
+        node_config
+    }
+
+    /// Generate `PeerInfo` and write `peer_info.toml`
+    pub fn generate_peer_info(
+        &self,
+        peer_id: &str,
+        consensus_peers: ConsensusPeersConfig,
+        network_peers: NetworkPeersConfig,
+    ) -> PeerInfo {
+        let consensus_info = consensus_peers.peers.into_iter().next().unwrap().1;
+        let network_info = network_peers.peers.into_iter().next().unwrap().1;
+        let peer_info = PeerInfo::new(
+            peer_id,
+            self.seed_address.as_ref(),
+            consensus_info,
+            network_info,
+        );
+
+        let peer_info_file = self.output_dir.join(peer_info::DEFAULT_FILENAME);
+        peer_info.save_config(&peer_info_file);
+        peer_info
+    }
+}
+
+/// Parse an IP address into a Multiaddr
+fn parse_multiaddr_from_ipv4(
+    ipv4_addr: impl Display,
+    port: u16,
+) -> Result<Multiaddr, parity_multiaddr::Error> {
+    format!("/ip4/{}/tcp/{}", ipv4_addr, port).parse()
+}

--- a/synchro/src/config/key_seed.rs
+++ b/synchro/src/config/key_seed.rs
@@ -1,0 +1,45 @@
+//! Key Seed: base derivation key for all node cryptographic (private) keys
+
+use hkd32::mnemonic;
+use std::convert::TryInto;
+
+/// Toplevel path component for personalizing all `synchro`-derived subkeys
+pub const TOPLEVEL_DERIVATION_COMPONENT: &[u8] = b"synchro";
+
+/// Key Seed
+#[derive(Clone)]
+pub struct KeySeed(mnemonic::Phrase);
+
+impl KeySeed {
+    /// Generate a random KeySeed
+    pub fn generate() -> Self {
+        KeySeed(mnemonic::Phrase::random(Default::default()))
+    }
+
+    /// Get the phrase for this `KeySeed` as a string
+    pub fn phrase(&self) -> &str {
+        self.0.phrase()
+    }
+
+    /// Derive a seed value given a domain and version
+    pub fn derive_seed(&self, domain: &[u8], version: u32) -> [u8; 32] {
+        let components = [
+            TOPLEVEL_DERIVATION_COMPONENT,
+            domain,
+            &version.to_le_bytes(),
+        ];
+
+        let mut derivation_path = hkd32::PathBuf::new();
+
+        for component in &components {
+            derivation_path.push(hkd32::Component::new(component).unwrap());
+        }
+
+        self.0
+            .clone()
+            .derive_subkey(&derivation_path)
+            .as_bytes()
+            .try_into()
+            .unwrap()
+    }
+}

--- a/synchro/src/config/peer_info.rs
+++ b/synchro/src/config/peer_info.rs
@@ -1,0 +1,55 @@
+//! `peer_info.toml` files used to build devnet genesis/configuration
+
+use libra_config::trusted_peers::{ConsensusPeerInfo, NetworkPeerInfo};
+use serde::{Deserialize, Serialize};
+
+/// Name of the `PeerInfo` file
+pub const DEFAULT_FILENAME: &str = "peer_info.toml";
+
+/// Public keys for a particular network peer
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PeerInfo {
+    /// Peer ID
+    pub id: String,
+
+    /// Optional description for this peer
+    #[serde(default)]
+    pub description: String,
+
+    /// Optional web site URL
+    #[serde(default)]
+    pub website_url: String,
+
+    /// Optional logo URL
+    #[serde(default)]
+    pub logo_url: String,
+
+    /// Seed IP address to include in `peer_info.toml`
+    pub seed_ip: Option<String>,
+
+    /// Consensus peer information
+    pub consensus: ConsensusPeerInfo,
+
+    /// Network peer information
+    pub network: NetworkPeerInfo,
+}
+
+impl PeerInfo {
+    /// Create new `PeerInfo` from the given peer ID, consensus and network peer info
+    pub fn new(
+        peer_id: impl ToString,
+        seed_ip: Option<impl ToString>,
+        consensus: ConsensusPeerInfo,
+        network: NetworkPeerInfo,
+    ) -> Self {
+        Self {
+            id: peer_id.to_string(),
+            description: Default::default(),
+            website_url: Default::default(),
+            logo_url: Default::default(),
+            seed_ip: seed_ip.map(|ip| ip.to_string()),
+            consensus,
+            network,
+        }
+    }
+}

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -2,18 +2,31 @@
 //! output for given argument combinations matches what is expected.
 
 #![forbid(unsafe_code)]
-#![warn(missing_docs, trivial_casts, unused_qualifications)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 use abscissa_core::testing::prelude::*;
-use lazy_static::lazy_static;
-
-lazy_static! {
-    pub static ref RUNNER: CmdRunner = CmdRunner::default();
-}
+use std::path::Path;
+use synchro::config::{ConsensusConfig, NetworkConfig, NodeConfig, PeerInfo, PersistableConfig};
+use tempfile::tempdir;
 
 #[test]
-fn start_no_args() {
-    let mut runner = RUNNER.clone();
-    let cmd = runner.arg("start").run();
+fn config_generator() {
+    let dir = tempdir().unwrap();
+
+    // Run `synchrnonicity init {dir.path()}`
+    run_synchronicity_init(dir.path());
+
+    // Make sure the generated config files load
+    ConsensusConfig::load_config(dir.path().join("consensus_keypair.config.toml"));
+    NetworkConfig::load_config(dir.path().join("network_keypairs.config.toml"));
+    NodeConfig::load_config(dir.path().join("node.config.toml"));
+    PeerInfo::load_config(dir.path().join("peer_info.toml"));
+}
+
+/// Run `synchronicity init`
+fn run_synchronicity_init(output_dir: &Path) {
+    let mut runner = CmdRunner::default();
+    let cmd = runner.arg("init").arg(output_dir).capture_stdout().run();
+
     cmd.wait().unwrap().expect_success();
 }


### PR DESCRIPTION
Generates initial set of node configuration files

TODO: `synchronicity.toml`, scratch directory