### PR TITLE
synchro: add Node and Launcher types

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -48,4 +48,3 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --deny-warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "generational-arena 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -33,14 +33,14 @@ dependencies = [
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "admission-control-proto"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -103,7 +103,7 @@ name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -127,7 +127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -137,8 +137,8 @@ name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -234,7 +234,7 @@ dependencies = [
 [[package]]
 name = "bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-semaphore 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -264,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytecode-verifier 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -273,7 +273,7 @@ dependencies = [
  "libra-failure-ext 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-types 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "libra-failure-ext 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-types 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -311,8 +311,8 @@ name = "bzip2-sys"
 version = "0.1.7"
 source = "git+https://github.com/alexcrichton/bzip2-rs.git#96cc4909a1a180a62ca8e3716785dc6f7a7f9ac0"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -366,7 +366,7 @@ dependencies = [
 [[package]]
 name = "channel"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -402,7 +402,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -416,7 +416,7 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -425,7 +425,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -441,7 +441,7 @@ name = "cmake"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "config-builder"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "generate-keypair 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "consensus"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -520,11 +520,11 @@ dependencies = [
  "safety-rules 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "schemadb 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-synchronizer 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "storage-client 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
- "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-runtime 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
 ]
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "executor 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-canonical-serialization 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -673,14 +673,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "1.2.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -702,7 +702,7 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "debug-interface"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -734,7 +734,7 @@ dependencies = [
  "libra-logger 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-metrics 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -754,7 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -780,7 +780,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -814,7 +814,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -824,13 +824,13 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -868,7 +868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -957,7 +957,7 @@ dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -981,13 +981,13 @@ dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-semaphore"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1026,7 +1026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "generate-keypair"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "libra-canonical-serialization 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-crypto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -1059,7 +1059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1069,7 +1069,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1078,7 +1078,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1090,7 +1090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grpc-helpers"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1108,7 +1108,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-sys 0.5.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1132,9 +1132,9 @@ version = "0.5.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1154,7 +1154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1166,7 +1166,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1187,7 +1187,7 @@ name = "hermit-abi"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1210,7 +1210,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1239,7 +1239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1257,7 +1257,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1272,7 +1272,7 @@ dependencies = [
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1305,13 +1305,13 @@ name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytecode-source-map 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1355,7 +1355,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1399,14 +1399,14 @@ name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libra-canonical-serialization"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "libra-config"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "libra-crypto"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1460,17 +1460,17 @@ dependencies = [
 [[package]]
 name = "libra-crypto-derive"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libra-failure-ext"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-failure-macros 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -1479,12 +1479,12 @@ dependencies = [
 [[package]]
 name = "libra-failure-macros"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 
 [[package]]
 name = "libra-logger"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1492,7 +1492,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-envlogger 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1504,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "libra-mempool"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bounded-executor 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "libra-mempool-shared-proto"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-failure-ext 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "libra-metrics"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1555,13 +1555,13 @@ dependencies = [
  "libra-failure-ext 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-logger 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libra-nibble"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "libra-prost-ext"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1578,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "libra-state-view"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "libra-failure-ext 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-types 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "libra-tools"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "libra-types"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1624,9 +1624,9 @@ version = "0.1.0"
 source = "git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libtitan_sys 0.0.1 (git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4-sys 1.8.3 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)",
@@ -1640,9 +1640,9 @@ version = "0.0.1"
 source = "git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4-sys 1.8.3 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)",
  "snappy-sys 0.1.0 (git+https://github.com/busyjay/rust-snappy.git?branch=static-link)",
@@ -1654,10 +1654,10 @@ name = "libz-sys"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1694,8 +1694,8 @@ name = "lz4-sys"
 version = "1.8.3"
 source = "git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#5a8afe4010c67899fc7af876a58d67fd6269bf81"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1732,7 +1732,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "mach_o_sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "memsocket"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1757,7 +1757,7 @@ dependencies = [
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1771,7 +1771,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1802,14 +1802,14 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "netcore"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "network"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "admission-control-proto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "bounded-executor 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -1870,13 +1870,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "noise"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-logger 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "netcore 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
- "snow 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1921,7 +1921,7 @@ version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1941,7 +1941,7 @@ dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2031,7 +2031,7 @@ name = "parking_lot_core"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2044,7 +2044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2085,7 +2085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2118,7 +2118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2128,7 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2253,7 +2253,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2265,7 +2265,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2283,7 +2283,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2374,7 +2374,7 @@ name = "rand_jitter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2386,7 +2386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2503,7 +2503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2511,9 +2511,9 @@ name = "ring"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2545,7 +2545,7 @@ version = "0.3.0"
 source = "git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59)",
 ]
 
@@ -2598,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "consensus-types 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-crypto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "schemadb"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-failure-ext 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -2634,7 +2634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -2647,7 +2647,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2679,12 +2679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2736,7 +2736,7 @@ name = "signal-hook"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2746,7 +2746,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2840,13 +2840,13 @@ version = "0.1.0"
 source = "git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44"
 dependencies = [
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "snow"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2858,7 +2858,7 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2879,7 +2879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "state-synchronizer"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "executor 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2901,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "stdlib"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytecode-source-map 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "bytecode-verifier 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -2913,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "storage-client"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "storage-proto"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2978,7 +2978,7 @@ dependencies = [
  "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2996,7 +2996,7 @@ name = "subtle-encoding"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3025,12 +3025,25 @@ version = "0.1.0"
 dependencies = [
  "consensus 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "executor 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpc-helpers 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkd32 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-crypto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "libra-failure-ext 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "libra-mempool 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "libra-state-view 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "libra-types 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "network 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "state-synchronizer 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "storage-client 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-runtime 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
+ "vm-validator 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
 ]
 
 [[package]]
@@ -3053,7 +3066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3068,7 +3081,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3094,10 +3107,10 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3108,7 +3121,7 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3116,7 +3129,7 @@ name = "thread-id"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3153,7 +3166,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3179,7 +3192,7 @@ dependencies = [
  "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3313,7 +3326,7 @@ version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3328,7 +3341,7 @@ dependencies = [
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3404,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-threadpool"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3468,7 +3481,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3483,7 +3496,7 @@ dependencies = [
 [[package]]
 name = "transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "ir-to-bytecode 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3540,7 +3553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3575,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3591,7 +3604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3607,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "vm-cache-map"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3616,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -3637,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bytecode-verifier 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3662,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "vm-runtime-types"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3678,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#72a17d70aa720982bd440cf3fd0cf1217d1123e0"
+source = "git+https://github.com/iqlusioninc/libra.git?branch=synchro#bccdfb30eab8217ebe8aef855ecaca4316b22a86"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)",
@@ -3695,7 +3708,7 @@ name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3742,7 +3755,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3762,7 +3775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3777,12 +3790,12 @@ name = "wasm-bindgen-webidl"
 version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3792,7 +3805,7 @@ name = "web-sys"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3813,7 +3826,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3883,12 +3896,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3909,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3922,18 +3935,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zstd-sys"
 version = "1.4.15+zstd.1.4.4"
-source = "git+https://github.com/gyscos/zstd-rs.git#9bdc44501ec3279e83d9bfe1ebc953bb7cf000b9"
+source = "git+https://github.com/gyscos/zstd-rs.git#e3e8452c934a8cb3007b7ea26c5052eaa2cfae48"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -3942,7 +3955,7 @@ dependencies = [
 "checksum admission-control-proto 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)" = "<none>"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b412394828b7ca486b362f300b762d8e43dafd6f0d727b63f1cd2ade207c6cef"
+"checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
@@ -3975,7 +3988,7 @@ dependencies = [
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 "checksum canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
-"checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+"checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
@@ -4006,7 +4019,7 @@ dependencies = [
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)" = "<none>"
-"checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
+"checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 "checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 "checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
@@ -4064,7 +4077,7 @@ dependencies = [
 "checksum hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 "checksum hkd32 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ec8449a5d1c7ea34a75bc45e91097d2768dfb056f37fa55a465f3c3ba7c0721"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-"checksum http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2790658cddc82e82b08e25176c431d7015a0adeb1718498715cbd20138a0bf68"
+"checksum http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
@@ -4081,7 +4094,7 @@ dependencies = [
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum libra-canonical-serialization 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)" = "<none>"
 "checksum libra-config 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)" = "<none>"
@@ -4215,7 +4228,7 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
-"checksum serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)" = "1a3351dcbc1f067e2c92ab7c3c1f288ad1a4cffc470b5aaddb4c2e0a3ae80043"
+"checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
@@ -4233,7 +4246,7 @@ dependencies = [
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
 "checksum snappy-sys 0.1.0 (git+https://github.com/busyjay/rust-snappy.git?branch=static-link)" = "<none>"
-"checksum snow 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91eecae35b461ed26bda7a76bea2cc5bda2bf4b8dd06761879f19e6fdd50c2dd"
+"checksum snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
@@ -4250,13 +4263,13 @@ dependencies = [
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 "checksum subtle-encoding 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc5188a16f729680b6d495b0deaa776944b8e509d24b7f989489b0d8bbcb63b"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+"checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
-"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
+"checksum termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "818ef3700c2a7b447dca1a1dd28341fe635e6ee103c806c636bb9c929991b2cd"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -4281,7 +4294,7 @@ dependencies = [
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-sync 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f1aaeb685540f7407ea0e27f1c9757d258c7c6bf4e3eb19da6fc59b747239d2"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
-"checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
+"checksum tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c32ffea4827978e9aa392d2f743d973c1dfa3730a2ed3f22ce1e6984da848c"
 "checksum tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 "checksum tokio-timer 0.3.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b97c1587fe71018eb245a4a9daa13a5a3b681bbc1f7fdadfe24720e141472c13"
 "checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
@@ -4296,13 +4309,13 @@ dependencies = [
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-"checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+"checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum vm 0.1.0 (git+https://github.com/iqlusioninc/libra.git?branch=synchro)" = "<none>"
@@ -4333,8 +4346,8 @@ dependencies = [
 "checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)" = "<none>"
-"checksum x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
+"checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 "checksum yamux 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2758f29014c1cb7a6e74c1b1160ac8c8203be342d35b73462fc6a13cc6385423"
-"checksum zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdc979d9b5ead18184c357c4d8a3f81b579aae264e32507223032e64715462d3"
+"checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 "checksum zstd-sys 1.4.15+zstd.1.4.4 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,6 +1,13 @@
-//! `start` subcommand
+//! `start` subcommand - launch Synchronicity node
 
+// Parts adapted from upstream Libra's `main_node.rs`:
+// <https://github.com/libra/libra/blob/master/libra-node/src/main_node.rs>
+//
+// Copyright (c) The Libra Core Contributors
+
+use crate::{executor::SynchronicityExecutor, prelude::*, verifier::VerifyProvider};
 use abscissa_core::{Command, Options, Runnable};
+use synchro::{config::NodeConfig, Launcher, Node};
 
 /// `start` subcommand
 #[derive(Command, Debug, Options)]
@@ -8,5 +15,17 @@ pub struct StartCmd {}
 
 impl Runnable for StartCmd {
     /// Start the application.
-    fn run(&self) {}
+    fn run(&self) {
+        let verify_provider = VerifyProvider::new();
+        let launcher = Launcher::new(self.load_node_config(), verify_provider).unwrap();
+        let _node: Node<SynchronicityExecutor> = launcher.launch().unwrap();
+    }
+}
+
+impl StartCmd {
+    /// Load the `NodeConfig`
+    fn load_node_config(&self) -> NodeConfig {
+        let cfg = app_config();
+        cfg.load_node_config()
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 use abscissa_core::Config;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use synchro::config::{NodeConfig, PersistableConfig};
 
 /// Synchronicity Configuration Filename
 pub const CONFIG_FILE: &str = "synchronicity.toml";
@@ -16,4 +17,11 @@ pub struct SynchronicityConfig {
 
     /// Scratch directory
     pub scratch_dir: PathBuf,
+}
+
+impl SynchronicityConfig {
+    /// Load [`NodeConfig`] from the configured location
+    pub fn load_node_config(&self) -> NodeConfig {
+        NodeConfig::load_config(&self.node_config)
+    }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,42 @@
+//! Synchronicity state machine executor
+
+use synchro::{
+    config::VMConfig,
+    error::Error,
+    state_view::StateView,
+    transaction::{SignedTransaction, Status, Transaction, TransactionOutput},
+    vm_runtime::{VMExecutor, VMVerifier},
+};
+
+/// State machine executor used by Synchronicity
+pub struct SynchronicityExecutor {}
+
+impl SynchronicityExecutor {
+    /// Create a new SynchronicityExecutor (stub!)
+    #[allow(clippy::new_without_default)] // sate clippy, for now
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl VMExecutor for SynchronicityExecutor {
+    fn execute_block(
+        _transactions: Vec<Transaction>,
+        _config: &VMConfig,
+        _state_view: &dyn StateView,
+    ) -> Result<Vec<TransactionOutput>, Error> {
+        // TODO(tarcieri): implement this!
+        unimplemented!();
+    }
+}
+
+impl VMVerifier for SynchronicityExecutor {
+    fn validate_transaction(
+        &self,
+        _transaction: SignedTransaction,
+        _state_view: &dyn StateView,
+    ) -> Option<Status> {
+        // TODO(tarcieri): implement this!
+        unimplemented!();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,4 +50,6 @@ pub mod application;
 pub mod commands;
 pub mod config;
 pub mod error;
+pub mod executor;
 pub mod prelude;
+pub mod verifier;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,0 +1,63 @@
+//! Transaction verifier
+
+use crate::executor::SynchronicityExecutor;
+use std::sync::Arc;
+use synchro::{
+    error::Error,
+    futures::future::Future,
+    storage_client::StorageRead,
+    transaction::{NewVerifier, SignedTransaction, Status, TransactionValidation},
+};
+
+/// Verification provider
+pub struct VerifyProvider {}
+
+impl VerifyProvider {
+    /// Create a new verify provider
+    #[allow(clippy::new_without_default)] // sate clippy, for now
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl NewVerifier for VerifyProvider {
+    type Verifier = Verifier;
+
+    /// Initialize a transaction validator from the given storage reader
+    fn new_verifier(&self, storage_read_client: Arc<dyn StorageRead>) -> Verifier {
+        Verifier::new(storage_read_client)
+    }
+}
+
+/// Validator for Synchronicity transactions
+#[allow(dead_code)] // TODO(tarcieri): verify stuff
+pub struct Verifier {
+    storage_read_client: Arc<dyn StorageRead>,
+    executor: SynchronicityExecutor,
+}
+
+impl Verifier {
+    pub fn new(storage_read_client: Arc<dyn StorageRead>) -> Self {
+        // TODO(tarcieri): make this real
+        let executor = SynchronicityExecutor::new();
+
+        Self {
+            storage_read_client,
+            executor,
+        }
+    }
+}
+
+impl TransactionValidation for Verifier {
+    type ValidationInstance = SynchronicityExecutor;
+
+    /// Validate transaction. See example here for how it's supposed to work:
+    ///
+    /// <https://github.com/libra/libra/blob/testnet/vm-validator/src/vm_validator.rs#L47>
+    fn validate_transaction(
+        &self,
+        _txn: SignedTransaction,
+    ) -> Box<dyn Future<Item = Option<Status>, Error = Error> + Send> {
+        unimplemented!();
+    }
+}

--- a/synchro/Cargo.toml
+++ b/synchro/Cargo.toml
@@ -18,20 +18,45 @@ keywords   = ["bft", "consensus", "hotstuff", "libra"]
 maintenance = { status = "experimental" }
 
 [dependencies]
+futures = "0.1.28"
+grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 hkd32 = { version = "0.3", features = ["mnemonic"] }
+log = "0.4"
 parity-multiaddr = { version = "0.5", default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
+tokio = "0.2.0-alpha.6"
 
 #
-# Libra Core Dependencies
+# Libra core dependencies
 #
 
-[dependencies.consensus]
+[dependencies.libra-config]
 git = "https://github.com/iqlusioninc/libra.git"
 branch = "synchro"
 
-[dependencies.crypto]
-package = "libra-crypto"
+[dependencies.libra-crypto]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.libra-failure-ext]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.libra-mempool]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.libra-state-view]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.libra-types]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+# Non-`libra` prefixed Libra core dependencies
+
+[dependencies.consensus]
 git = "https://github.com/iqlusioninc/libra.git"
 branch = "synchro"
 
@@ -39,11 +64,26 @@ branch = "synchro"
 git = "https://github.com/iqlusioninc/libra.git"
 branch = "synchro"
 
-[dependencies.libra-config]
+[dependencies.grpc-helpers]
 git = "https://github.com/iqlusioninc/libra.git"
 branch = "synchro"
 
-[dependencies.types]
-package = "libra-types"
+[dependencies.network]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.state-synchronizer]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.storage-client]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.vm-runtime]
+git = "https://github.com/iqlusioninc/libra.git"
+branch = "synchro"
+
+[dependencies.vm-validator]
 git = "https://github.com/iqlusioninc/libra.git"
 branch = "synchro"

--- a/synchro/src/crypto.rs
+++ b/synchro/src/crypto.rs
@@ -1,0 +1,3 @@
+//! Crypto dependencies
+
+pub use libra_crypto::{bls12381, ed25519, hash, hkdf, slip0010, test_utils, traits, vrf, x25519};

--- a/synchro/src/error.rs
+++ b/synchro/src/error.rs
@@ -1,0 +1,3 @@
+//! Error types
+
+pub use libra_failure_ext::{Error, Result};

--- a/synchro/src/launcher.rs
+++ b/synchro/src/launcher.rs
@@ -1,0 +1,332 @@
+//! Launcher - starts a node with the given configuration an executor
+
+use crate::{error::Error, node::Node, transaction::NewVerifier};
+use std::{
+    convert::TryInto,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+// Libra types
+
+use consensus::consensus_provider::{make_consensus_provider, ConsensusProvider};
+use executor::Executor;
+use grpc_helpers::ServerHandle;
+use grpcio::EnvBuilder;
+use libra_config::config::{NodeConfig, RoleType};
+use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_mempool::{core_mempool::CoreMempool, mempool_service::MempoolService, MempoolRuntime};
+use libra_types::account_address::AccountAddress as PeerId;
+use log::debug;
+use network::{
+    validator_network::{
+        network_builder::{NetworkBuilder, TransportType},
+        ConsensusNetworkEvents,
+        ConsensusNetworkSender,
+        LibraNetworkProvider,
+        // when you add a new protocol const, you must add this in either
+        // .direct_send_protocols or .rpc_protocols vector of network_builder in setup_network()
+        ADMISSION_CONTROL_RPC_PROTOCOL,
+        CONSENSUS_DIRECT_SEND_PROTOCOL,
+        CONSENSUS_RPC_PROTOCOL,
+        MEMPOOL_DIRECT_SEND_PROTOCOL,
+        STATE_SYNCHRONIZER_MSG_PROTOCOL,
+    },
+    NetworkPublicKeys, ProtocolId,
+};
+use state_synchronizer::StateSynchronizer;
+use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceClient};
+use tokio::runtime::Runtime;
+use vm_runtime::VMExecutor;
+
+/// Launcher - launches a Synchro node
+pub struct Launcher<V: NewVerifier> {
+    /// Node configuration
+    node_config: NodeConfig,
+
+    /// Peer ID
+    peer_id: PeerId,
+
+    /// Node role
+    role: RoleType,
+
+    /// Transaction verification provider
+    verify_provider: V,
+}
+
+impl<V> Launcher<V>
+where
+    V: NewVerifier,
+{
+    /// Create a new launcher
+    pub fn new(node_config: NodeConfig, verify_provider: V) -> Result<Self, Error> {
+        if let Some(net_config) = node_config.networks.get(0) {
+            let peer_id = PeerId::from_hex_literal(&net_config.peer_id)?;
+            let role = RoleType::from(&net_config.role);
+
+            Ok(Self {
+                node_config,
+                peer_id,
+                role,
+                verify_provider,
+            })
+        } else {
+            // TODO(tarcieri): don't panic!
+            panic!(
+                "unexpected number of network configs: {} (expected 1)",
+                node_config.networks.len()
+            );
+        }
+    }
+
+    /// Launch the node
+    pub fn launch<E>(mut self) -> Result<Node<E>, Error>
+    where
+        E: VMExecutor + Send + Sync + 'static,
+    {
+        let runtime = crate::start_runtime();
+        let mut network_provider = self.start_network_provider(&runtime);
+
+        // Note: We need to start network provider before consensus, because the consensus
+        // initialization is blocked on state synchronizer to sync to the initial root ledger
+        // info, which in turn cannot make progress before network initialization
+        // because the NewPeer events which state synchronizer uses to know its
+        // peers are delivered by network provider. If we were to start network
+        // provider after consensus, we create a cyclic dependency from
+        // network provider -> consensus -> state synchronizer -> network provider. This deadlock
+        // was observed in GitHub Issue #749. A long term fix might be make
+        // consensus initialization async instead of blocking on state synchronizer.
+        let mempool = self.start_mempool(network_provider.as_mut());
+
+        let (consensus_network_sender, consensus_network_events) =
+            network_provider.add_consensus(vec![
+                ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL),
+                ProtocolId::from_static(CONSENSUS_DIRECT_SEND_PROTOCOL),
+            ]);
+
+        runtime.executor().spawn(network_provider.start());
+        debug!("network started for peer_id: {}", &self.peer_id);
+
+        let executor = self.start_executor();
+        let consensus = self.start_consensus_provider(
+            Arc::clone(&executor),
+            consensus_network_sender,
+            consensus_network_events,
+        )?;
+
+        Ok(Node {
+            runtime,
+            consensus,
+            mempool,
+            executor,
+        })
+    }
+
+    /// Start the network provider
+    fn start_network_provider(&mut self, runtime: &Runtime) -> Box<dyn LibraNetworkProvider> {
+        // NOTE: this is asserted to exist in `Launcher::new`
+        let network_signing_private = self.node_config.networks[0].network_keypairs.take_network_signing_private().expect(
+            "failed to move network signing private key out of NodeConfig: key not set or moved already"
+        );
+
+        let network_signing_public = Ed25519PublicKey::from(&network_signing_private);
+
+        // NOTE: this is asserted to exist in `Launcher::new`
+        let network_config = &self.node_config.networks[0];
+
+        let mut network_builder = NetworkBuilder::new(
+            runtime.executor(),
+            self.peer_id,
+            network_config.listen_address.clone(),
+            self.role,
+        );
+
+        network_builder
+            .permissioned(network_config.is_permissioned)
+            .advertised_address(network_config.advertised_address.clone())
+            .direct_send_protocols(vec![
+                ProtocolId::from_static(CONSENSUS_DIRECT_SEND_PROTOCOL),
+                ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL),
+                ProtocolId::from_static(STATE_SYNCHRONIZER_MSG_PROTOCOL),
+            ])
+            .rpc_protocols(vec![
+                ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL),
+                ProtocolId::from_static(ADMISSION_CONTROL_RPC_PROTOCOL),
+            ]);
+
+        let trusted_peers = network_config
+            .network_peers
+            .peers
+            .iter()
+            .map(|(peer_id, keys)| {
+                (
+                    PeerId::from_str(peer_id).unwrap(),
+                    NetworkPublicKeys {
+                        signing_public_key: keys.network_signing_pubkey.clone(),
+                        identity_public_key: keys.network_identity_pubkey.clone(),
+                    },
+                )
+            })
+            .collect();
+
+        let seed_peers = network_config
+            .seed_peers
+            .seed_peers
+            .clone()
+            .into_iter()
+            .map(|(peer_id, addrs)| (peer_id.try_into().expect("invalid PeerId"), addrs))
+            .collect();
+
+        network_builder
+            .transport(TransportType::TcpNoise(Some(
+                network_config
+                    .network_keypairs
+                    .get_network_identity_keypair(),
+            )))
+            .connectivity_check_interval_ms(network_config.connectivity_check_interval_ms)
+            .seed_peers(seed_peers)
+            .trusted_peers(trusted_peers)
+            .signing_keys((network_signing_private, network_signing_public))
+            .discovery_interval_ms(network_config.discovery_interval_ms);
+
+        let (listen_addr, network_provider) = network_builder.build();
+        debug!("listen addr: {:?}", listen_addr);
+
+        network_provider
+    }
+
+    /// Start the mempool for this node
+    fn start_mempool(&self, network_provider: &mut dyn LibraNetworkProvider) -> MempoolRuntime {
+        let (network_sender, network_events) = network_provider
+            .add_mempool(vec![ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL)]);
+
+        // Initialize and start mempool.
+        let instant = Instant::now();
+
+        let config = &self.node_config;
+        let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
+        let cq_count = 2; // TODO: customize count based on CPUs?
+
+        // setup grpc server
+        let env = Arc::new(
+            EnvBuilder::new()
+                .name_prefix("grpc-mempool-")
+                .cq_count(cq_count)
+                .build(),
+        );
+
+        let handle = MempoolService {
+            core_mempool: Arc::clone(&mempool),
+        };
+
+        let service = libra_mempool::proto::mempool::create_mempool(handle);
+        let grpc_server = grpcio::ServerBuilder::new(env)
+            .register_service(service)
+            .bind(
+                config.mempool.address.clone(),
+                config.mempool.mempool_service_port,
+            )
+            .build()
+            .expect("[mempool] unable to create grpc server");
+
+        // setup shared mempool
+        let storage_client: Arc<dyn StorageRead> = Arc::new(StorageReadServiceClient::new(
+            Arc::new(EnvBuilder::new().name_prefix("grpc-mem-sto-").build()),
+            "localhost",
+            config.storage.port,
+        ));
+
+        let verifier = Arc::new(
+            self.verify_provider
+                .new_verifier(Arc::clone(&storage_client)),
+        );
+
+        // TODO(tarcieri): mempool subscribers?
+        let subscribers = vec![];
+
+        // TODO(tarcieri): timer?
+        let timer = None;
+
+        let shared_mempool = libra_mempool::shared_mempool::start_shared_mempool(
+            config,
+            mempool,
+            network_sender,
+            network_events,
+            storage_client,
+            verifier,
+            subscribers,
+            timer,
+        );
+
+        debug!("mempool started in {} ms", instant.elapsed().as_millis());
+
+        MempoolRuntime {
+            grpc_server: ServerHandle::setup(grpc_server),
+            shared_mempool,
+        }
+    }
+
+    /// Start the consensus provider
+    fn start_consensus_provider<E>(
+        &mut self,
+        executor: Arc<Executor<E>>,
+        consensus_network_sender: ConsensusNetworkSender,
+        consensus_network_events: ConsensusNetworkEvents,
+    ) -> Result<Box<dyn ConsensusProvider>, Error>
+    where
+        E: VMExecutor + Send + Sync + 'static,
+    {
+        // Initialize and start consensus.
+        let instant = Instant::now();
+
+        // TODO(tarcieri): populate these?
+        let state_sync_network_handles = vec![];
+
+        let state_synchronizer = StateSynchronizer::bootstrap(
+            state_sync_network_handles,
+            Arc::clone(&executor),
+            &self.node_config,
+        );
+
+        let mut consensus_provider = make_consensus_provider(
+            &mut self.node_config,
+            consensus_network_sender,
+            consensus_network_events,
+            executor,
+            state_synchronizer.create_client(),
+        );
+
+        consensus_provider.start()?;
+        debug!("consensus started in {} ms", instant.elapsed().as_millis());
+
+        Ok(consensus_provider)
+    }
+
+    /// Start the executor for this node
+    fn start_executor<E>(&self) -> Arc<Executor<E>>
+    where
+        E: VMExecutor + Send + Sync + 'static,
+    {
+        let client_env = Arc::new(EnvBuilder::new().name_prefix("grpc-exe-sto-").build());
+
+        let storage_read_client = Arc::new(StorageReadServiceClient::new(
+            Arc::clone(&client_env),
+            &self.node_config.storage.address,
+            self.node_config.storage.port,
+        ));
+
+        let storage_write_client = Arc::new(StorageWriteServiceClient::new(
+            Arc::clone(&client_env),
+            &self.node_config.storage.address,
+            self.node_config.storage.port,
+            self.node_config.storage.grpc_max_receive_len,
+        ));
+
+        Arc::new(Executor::new(
+            Arc::clone(&storage_read_client) as Arc<dyn StorageRead>,
+            storage_write_client,
+            &self.node_config,
+        ))
+    }
+}

--- a/synchro/src/lib.rs
+++ b/synchro/src/lib.rs
@@ -1,7 +1,38 @@
 //! Synchro
 
+// Modules
 pub mod config;
+pub mod crypto;
+pub mod error;
+pub mod launcher;
+pub mod node;
+pub mod transaction;
 
+// Crate re-exports
+pub use grpcio;
+
+// Libra re-exports
 pub use consensus;
 pub use executor;
-pub use types;
+pub use futures;
+pub use libra_mempool as mempool;
+pub use libra_state_view as state_view;
+pub use libra_types as types;
+pub use network;
+pub use state_synchronizer;
+pub use storage_client;
+pub use vm_runtime;
+pub use vm_validator;
+
+// Other re-exports
+pub use tokio;
+
+pub use self::{launcher::Launcher, node::Node};
+
+/// Helper to initialize a Tokio runtime
+pub fn start_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new()
+        .name_prefix("synchro-")
+        .build()
+        .unwrap_or_else(|e| panic!("couldn't initialize Tokio runtime: {}", e))
+}

--- a/synchro/src/node.rs
+++ b/synchro/src/node.rs
@@ -1,0 +1,25 @@
+//! Synchronicity node type: owns all state for a running node
+
+use consensus::consensus_provider::ConsensusProvider;
+use executor::Executor;
+use libra_mempool::MempoolRuntime;
+use std::sync::Arc;
+use vm_runtime::VMExecutor;
+
+/// Synchronicity full node runtime
+pub struct Node<V>
+where
+    V: VMExecutor + Send + Sync + 'static,
+{
+    /// Tokio runtime
+    pub runtime: tokio::runtime::Runtime,
+
+    /// Consensus provider
+    pub consensus: Box<dyn ConsensusProvider>,
+
+    /// Mempool runtime
+    pub mempool: MempoolRuntime,
+
+    /// Executor
+    pub executor: Arc<Executor<V>>,
+}

--- a/synchro/src/transaction.rs
+++ b/synchro/src/transaction.rs
@@ -1,0 +1,20 @@
+//! Transaction-related types/traits
+
+pub use libra_types::{
+    transaction::{SignedTransaction, Transaction, TransactionOutput},
+    vm_error::VMStatus as Status,
+};
+pub use vm_runtime::VMVerifier;
+pub use vm_validator::vm_validator::TransactionValidation;
+
+use std::sync::Arc;
+use storage_client::StorageRead;
+
+/// Initialize a `TransactionValidation`-capable transaction validator
+pub trait NewVerifier: Send + Sync {
+    /// Transaction validator type this trait produces
+    type Verifier: TransactionValidation + 'static;
+
+    /// Initialize a transaction validator from the given storage reader
+    fn new_verifier(&self, storage_read_client: Arc<dyn StorageRead>) -> Self::Verifier;
+}


### PR DESCRIPTION
Adds a `Launcher` type which contains much of the logic of `libra-node`, but modified and customized to support generic `VMExecutor`/`VMVerifier` types (probably best leveraged as a single type that impls both).

This seems like a good potential use case for Abscissa components, and perhaps all of the `Launcher::start_*` methods can eventually be refactored into components that wrap the relevant Libra types, but for now it's just one big type with a bunch of methods that start things up in the "right" order (hopefully).