### PR TITLE
Build `develop` branch in CI; fix README.md badge

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@
 on:
   pull_request: {}
   push:
-    branches: master
+    branches: develop
 
 name: Rust
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ without any additional terms or conditions.
 
 [//]: # (badges)
 
-[build-image]: https://github.com/iqlusioninc/synchronicity/workflows/Rust/badge.svg
+[build-image]: https://github.com/iqlusioninc/synchronicity/workflows/Rust/badge.svg?branch=develop&event=push
 [build-link]: https://github.com/iqlusioninc/synchronicity/actions
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/


### PR DESCRIPTION
Spurious failing PRs were causing it to fail before.